### PR TITLE
update Hero-Carousel to use target _self instead of _blank

### DIFF
--- a/etownws-widgets/frontpage-widgets/Hero-Carousel-ETW/widget.html
+++ b/etownws-widgets/frontpage-widgets/Hero-Carousel-ETW/widget.html
@@ -163,7 +163,7 @@
     function attachClickListener(image) {
       image.addEventListener('click', function() {
         const redirectLink = this.getAttribute('data-redirect');
-        window.open(redirectLink, '_blank');
+        window.open(redirectLink, '_self');
       });
     }
 


### PR DESCRIPTION
## Description
Changed the target of image redirect on Hero Carousel images to ` _self ` from ` _blank ` to open products in the same tab rather than a new tab.

[window.open(url, target) documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#target)

## Affected site section
![image](https://github.com/Etown-Marketing-and-Distributing/widget-builder-etw/assets/56705400/0617b2a9-7d06-4055-92f2-091c9b48ac54)