### PR TITLE
Initial Addition of desktop and mobile nav menus

### DIFF
--- a/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Content-ETW/config.json
+++ b/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Content-ETW/config.json
@@ -1,0 +1,51 @@
+{
+  "text": "Simple Text with Styling",
+  "_.id": "1",
+  "color": "white",
+  "background_color": "#3C1F8C",
+  "font_size": {
+    "value": 24,
+    "type": "px"
+  },
+  "font_weight": "bold",
+  "text_align": {
+    "horizontal": "center"
+  },
+  "margin": {
+    "top": {
+      "value": "0",
+      "type": "px"
+    },
+    "right": {
+      "value": "0",
+      "type": "px"
+    },
+    "bottom": {
+      "value": "0",
+      "type": "px"
+    },
+    "left": {
+      "value": "0",
+      "type": "px"
+    }
+  },
+  "padding": {
+    "top": {
+      "value": "8",
+      "type": "px"
+    },
+    "right": {
+      "value": "24",
+      "type": "px"
+    },
+    "bottom": {
+      "value": "8",
+      "type": "px"
+    },
+    "left": {
+      "value": "24",
+      "type": "px"
+    }
+  },
+  "content": "I am a sample text"
+}

--- a/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Content-ETW/schema.json
+++ b/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Content-ETW/schema.json
@@ -1,0 +1,348 @@
+[
+  {
+    "type": "array",
+    "label": "Navigation Sections",
+    "id": "nav_content_columns",
+    "defaultCount": 0,
+    "entryLabel": "Nav Section",
+    "schema": [
+      {
+        "type": "tab",
+        "label": "Design",
+        "sections": [
+          {
+            "label":"Categories",
+            "settings": [
+              {
+                "type": "input",
+                "id": "category_label",
+                "label": "Category Label"
+              },
+              {
+                "type": "input",
+                "id": "category_page_url",
+                "label": "Category Page URL"
+              },
+              {
+                "type": "input",
+                "id": "brand_label_1",
+                "label": "Brand Label 1"
+              },
+              {
+                "type": "input",
+                "id": "brand_page_url_1",
+                "label": "Brand Page URL 1"
+              },
+              {
+                "type": "input",
+                "id": "brand_label_2",
+                "label": "Brand Label 2"
+              },
+              {
+                "type": "input",
+                "id": "brand_page_url_2",
+                "label": "Brand Page URL 2"
+              },
+              {
+                "type": "input",
+                "id": "brand_label_3",
+                "label": "Brand Label 3"
+              },
+              {
+                "type": "input",
+                "id": "brand_page_url_3",
+                "label": "Brand Page URL 3"
+              },
+              {
+                "type": "input",
+                "id": "brand_label_4",
+                "label": "Brand Label 4"
+              },
+              {
+                "type": "input",
+                "id": "brand_page_url_4",
+                "label": "Brand Page URL 4"
+              },
+              {
+                "type": "input",
+                "id": "brand_label_5",
+                "label": "Brand Label 5"
+              },
+              {
+                "type": "input",
+                "id": "brand_page_url_5",
+                "label": "Brand Page URL 5"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "tab",
+        "label": "Design",
+        "sections": [
+          {
+            "label":"Brand Image",
+            "settings": [
+              {
+                "type": "imageManager",
+                "id": "brand_image",
+                "label": "Brand Image",
+                "default": {
+                  "src": "",
+                  "type": "IMAGE_MANAGER"
+                }
+              },
+              {
+                "type": "input",
+                "id": "brand_image_url",
+                "label": "Brand Image URL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "tab",
+        "label": "Design",
+        "sections": [
+          {
+            "label":"Featured Image",
+            "settings": [
+              {
+                "type": "imageManager",
+                "id": "featured_product_image",
+                "label": "Featured Product Image",
+                "default": {
+                  "src": "",
+                  "type": "IMAGE_MANAGER"
+                }
+              },
+              {
+                "type": "input",
+                "id": "featured_product_image_url",
+                "label": "Featured Image URL"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "tab",
+    "label": "Category Links",
+    "sections": [
+      {
+        "label":"Category Settings",
+        "settings": [
+          {
+            "type": "input",
+            "id": "nav_section_category_count",
+            "label": "Number of category groups"
+          },
+          {
+            "type": "input",
+            "id": "nav_section_category_header_font_size",
+            "label": "Category header font size (px)"
+          },
+          {
+            "type": "input",
+            "id": "nav_section_category_header_font_weight",
+            "label": "Category header font weight"
+          },
+          {
+            "type": "color",
+            "label": "Category header font color",
+            "id": "nav_section_category_header_font_color"
+          },
+          {
+            "type": "input",
+            "id": "nav_section_category_font_size",
+            "label": "Category link font size (px)"
+          },
+          {
+            "type": "input",
+            "label": "Category link font weight",
+            "id": "nav_section_category_font_weight"
+          },
+          {
+            "type": "color",
+            "label": "Category link font color",
+            "id": "nav_section_category_font_color"
+          },
+          {
+            "type": "boxModel",
+            "label": "Category Group Margins (px)",
+            "id": "nav_section_categories_margins",
+            "default": {
+                "top": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "right": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "bottom": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "left": {
+                    "value": "0",
+                    "type": "px"
+                }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "tab",
+    "label": "Brand Images",
+    "sections": [
+      {
+        "label":"Brand Image Settings",
+        "settings": [
+          {
+            "type": "input",
+            "id": "nav_section_brand_count",
+            "label": "Number of brand images"
+          },
+          {
+            "type": "input",
+            "id": "nav_section_brand_img_width",
+            "label": "Brand Image Width (px)"
+          },
+          {
+            "type": "input",
+            "id": "nav_section_brand_img_height",
+            "label": "Brand Image Height (px)"
+          },
+          {
+            "type": "boxModel",
+            "label": "Brand Image Margins (px)",
+            "id": "nav_section_brand_img_margins",
+            "default": {
+                "top": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "right": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "bottom": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "left": {
+                    "value": "0",
+                    "type": "px"
+                }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "tab",
+    "label": "Featured Images",
+    "sections": [
+      {
+        "label":"Featured Image Settings",
+        "settings": [
+          {
+            "type": "input",
+            "id": "nav_section_featured_count",
+            "label": "Number of featured product images"
+          },
+          {
+            "type": "input",
+            "id": "nav_section_featured_img_width",
+            "label": "Featured Image Width (px)"
+          },
+          {
+            "type": "input",
+            "id": "nav_section_featured_img_height",
+            "label": "Featured Image Height (px)"
+          },
+          {
+            "type": "boxModel",
+            "label": "Featured Image Margins (px)",
+            "id": "nav_section_featured_img_margins",
+            "default": {
+                "top": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "right": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "bottom": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "left": {
+                    "value": "0",
+                    "type": "px"
+                }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "tab",
+    "label": "Section Design",
+    "sections": [
+      {
+        "label":"Container Settings",
+        "settings": [
+          {
+            "type": "input",
+            "label": "Section Name (Nav Bar Button Label)",
+            "id": "nav_section_name"
+          },
+          {
+            "type": "input",
+            "label": "Blur Amount (px)",
+            "id": "nav_section_blur"
+          },
+          {
+            "type": "color",
+            "label": "Background Color",
+            "id": "nav_section_background_color"
+          },
+          {
+            "type": "boxModel",
+            "label": "Padding (px)",
+            "id": "nav_section_padding",
+            "default": {
+                "top": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "right": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "bottom": {
+                    "value": "20",
+                    "type": "px"
+                },
+                "left": {
+                    "value": "0",
+                    "type": "px"
+                }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Content-ETW/widget.html
+++ b/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Content-ETW/widget.html
@@ -1,0 +1,168 @@
+<script>
+    if(!navBarButtonListener)
+    var navBarButtonListener = (e) => {
+        document.querySelectorAll(".navSectionContent-container.open").forEach((element) => {
+            element.classList.remove("open");
+            element.classList.add("closed");
+        });
+        let tabToOpen = document.querySelector(`.navSectionContent-container[data-nav-section-name='${e.srcElement.dataset.navButtonSection}']`);
+        tabToOpen.classList.remove("closed");
+        tabToOpen.classList.add("open");
+    }
+    document.addEventListener("DOMContentLoaded", (event) => {
+        if(jsContext.settings.request.referer.includes("/manage/page-builder")) {
+            let styleEle = document.createElement("style");
+            styleEle.innerHTML = ".navSectionContent-container {position: relative !important; display: flex !important;}";
+            document.body.append(styleEle);
+        }
+    });
+    document.querySelector(".navBarButton[data-nav-button-section='{{nav_section_name}}']").addEventListener("click", navBarButtonListener);
+</script>
+<style>
+
+    @keyframes navSectionContent-fadeIn {
+        0% {
+            opacity: 0;
+        }
+
+        100% {
+            opacity: 1;
+        }
+    }
+    @keyframes navSectionContent-fadeOut {
+        0% {
+            opacity: 1;
+            display: flex;
+        }
+
+        100% {
+            opacity: 0;
+            display: none;
+        }
+    }
+
+    [data-content-region="nav_bar--global"] {
+            [data-sub-layout-container] {
+                z-index: auto !important;
+
+                [data-sub-layout] {
+                    z-index: auto !important;
+                }
+            }
+        }
+
+    .navSectionContent-{{_.id}} {
+
+        &.navSectionContent-container {
+            min-height: 100px;
+            max-width: 100%;
+            width: 100vw;
+            position: absolute;
+            z-index: 10;
+            flex-wrap: wrap;
+            color: black;
+            justify-content: center;
+            -webkit-backdrop-filter: blur(6px);
+            {{#if nav_section_blur}}
+            backdrop-filter: blur({{nav_section_blur}}px);
+            {{else}}
+            background-color: {{nav_section_background_color}};
+            {{/if}}
+            box-shadow: 0px 8px 20px -20px black;
+            padding: {{nav_section_padding.top.value}}{{nav_section_padding.top.type}} {{nav_section_padding.right.value}}{{nav_section_padding.right.type}} {{nav_section_padding.bottom.value}}{{nav_section_padding.bottom.type}} {{nav_section_padding.left.value}}{{nav_section_padding.left.type}};
+
+            &.open {
+                display: flex;
+                animation: .5s navSectionContent-fadeIn;
+            }
+
+            &.closed {
+                display: none;
+                animation: .5s navSectionContent-fadeOut;
+            }
+
+            a {
+                text-decoration: none;
+            }
+        }
+
+        .navSectionContent-categories {
+            order:1;
+            margin: {{nav_section_categories_margins.top.value}}{{nav_section_categories_margins.top.type}} {{nav_section_categories_margins.right.value}}{{nav_section_categories_margins.right.type}} {{nav_section_categories_margins.bottom.value}}{{nav_section_categories_margins.bottom.type}} {{nav_section_categories_margins.left.value}}{{nav_section_categories_margins.left.type}};
+        
+            div {
+                {{#if nav_section_category_font_color}}color: {{nav_section_category_font_color}};{{/if}}
+                font-size: {{nav_section_category_font_size}}px;
+                font-weight: {{nav_section_category_font_weight}};
+            }
+
+            h2 {
+                {{#if nav_section_category_header_font_color}}color: {{nav_section_category_header_font_color}};{{/if}}
+                font-size: {{nav_section_category_header_font_size}}px;
+                font-weight: {{nav_section_category_header_font_weight}};
+            }
+        
+        }
+
+        .navSectionContent-categoriesBreak {
+            order:2;
+            flex-basis:100%;
+        }
+
+        .navSectionContent-brandImage {
+            order:3;
+
+            width: {{nav_section_brand_img_width}}px;
+            height: {{nav_section_brand_img_height}}px;
+            margin: {{nav_section_brand_img_margins.top.value}}{{nav_section_brand_img_margins.top.type}} {{nav_section_brand_img_margins.right.value}}{{nav_section_brand_img_margins.right.type}} {{nav_section_brand_img_margins.bottom.value}}{{nav_section_brand_img_margins.bottom.type}} {{nav_section_brand_img_margins.left.value}}{{nav_section_brand_img_margins.left.type}};
+            overflow:hidden;
+            align-content:center;
+
+        }
+
+        .navSectionContent-brandImageBreak {
+            order:4;
+            flex-basis:100%;
+        }
+
+        .navSectionContent-featuredProduct {
+            order:5;
+
+            width: {{nav_section_featured_img_width}}px;
+            height: {{nav_section_featured_img_height}}px;
+            margin: {{nav_section_featured_img_margins.top.value}}{{nav_section_featured_img_margins.top.type}} {{nav_section_featured_img_margins.right.value}}{{nav_section_featured_img_margins.right.type}} {{nav_section_featured_img_margins.bottom.value}}{{nav_section_featured_img_margins.bottom.type}} {{nav_section_featured_img_margins.left.value}}{{nav_section_featured_img_margins.left.type}};
+            overflow: hidden;
+            align-content:center;
+
+        }
+    }
+
+</style>
+    
+<div class="navSectionContent-container navSectionContent-{{_.id}} closed" data-nav-section-name="{{nav_section_name}}">
+    <div class="navSectionContent-categoriesBreak"></div>
+    <div class="navSectionContent-brandImageBreak"></div>
+    {{#each nav_content_columns}}
+        {{#if category_label}}
+            <div class="navSectionContent-categories">
+                <h2><a {{#if category_page_url}}href="{{category_page_url}}"{{/if}}>{{category_label}}</a></h2>
+                {{#if brand_label_1}}<div><a {{#if brand_page_url_1}}href="{{brand_page_url_1}}"{{/if}}>{{brand_label_1}}</a></div>{{/if}}
+                {{#if brand_label_2}}<div><a {{#if brand_page_url_2}}href="{{brand_page_url_2}}"{{/if}}>{{brand_label_2}}</a></div>{{/if}}
+                {{#if brand_label_3}}<div><a {{#if brand_page_url_3}}href="{{brand_page_url_3}}"{{/if}}>{{brand_label_3}}</a></div>{{/if}}
+                {{#if brand_label_4}}<div><a {{#if brand_page_url_4}}href="{{brand_page_url_4}}"{{/if}}>{{brand_label_4}}</a></div>{{/if}}
+                {{#if brand_label_5}}<div><a {{#if brand_page_url_5}}href="{{brand_page_url_5}}"{{/if}}>{{brand_label_5}}</a></div>{{/if}}
+            </div>
+        {{/if}}
+        {{#if brand_image.src}}
+            <div class="navSectionContent-brandImage">
+                <a {{#if brand_image_url}}href="{{brand_image_url}}"{{/if}}><img src="{{brand_image.src}}"></a>
+            </div>
+        {{/if}}
+        {{#if featured_product_image.src}}
+            <div class="navSectionContent-featuredProduct">
+                <a {{#if featured_product_image_url}}href="{{featured_product_image_url}}"{{/if}}><img src="{{featured_product_image.src}}"></a>
+            </div>
+        {{/if}}
+    {{/each}}
+</div>
+

--- a/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Navbar-ETW/config.json
+++ b/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Navbar-ETW/config.json
@@ -1,0 +1,44 @@
+{
+  "nav_sections": [
+    {
+      "nav_bar_button_color": "#363636",
+      "nav_bar_button_color_hover": "#263178"
+    }
+  ],
+  "nav_bar_button_margins": {
+    "top": {
+      "value": "0",
+      "type": "px"
+    },
+    "right": {
+      "value": "0",
+      "type": "px"
+    },
+    "bottom": {
+      "value": "0",
+      "type": "px"
+    },
+    "left": {
+      "value": "0",
+      "type": "px"
+    }
+  },
+  "nav_bar_margins": {
+    "top": {
+      "value": "0",
+      "type": "px"
+    },
+    "right": {
+      "value": "0",
+      "type": "px"
+    },
+    "bottom": {
+      "value": "0",
+      "type": "px"
+    },
+    "left": {
+      "value": "0",
+      "type": "px"
+    }
+  }
+}

--- a/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Navbar-ETW/schema.json
+++ b/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Navbar-ETW/schema.json
@@ -1,0 +1,125 @@
+[
+  {
+    "type": "array",
+    "label": "Navigation Sections",
+    "id": "nav_sections",
+    "defaultCount": 0,
+    "entryLabel": "Nav Section",
+    "schema": [
+      {
+        "type": "tab",
+        "label": "Design",
+        "sections": [
+          {
+            "settings": [
+              {
+                "type": "input",
+                "id": "nav_bar_section_label",
+                "label": "Section Label"
+              },
+              {
+                "type": "input",
+                "id": "nav_bar_button_url",
+                "label": "Page URL"
+              },
+              {
+                "type": "color",
+                "id": "nav_bar_button_color",
+                "label": "Button Color",
+                "default":"#363636"
+              },
+              {
+                "type": "color",
+                "id": "nav_bar_button_color_hover",
+                "label": "Button Hover Color",
+                "default": "#263178"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "tab",
+    "label": "Design",
+    "sections": [
+      {
+        "label":"Button Settings",
+        "settings": [
+          {
+            "type": "input",
+            "id": "nav_bar_button_width",
+            "label": "Button Default Width (px)"
+          },
+          {
+            "type": "input",
+            "id": "nav_bar_button_font_size",
+            "label": "Button Font Size (px)"
+          },
+          {
+            "type": "input",
+            "id": "nav_bar_button_border_radius",
+            "label": "Button Border Radius (px)"
+          },
+          {
+            "type": "boxModel",
+            "label": "Nav Bar Button Margins (px)",
+            "id": "nav_bar_button_margins",
+            "default": {
+                "top": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "right": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "bottom": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "left": {
+                    "value": "0",
+                    "type": "px"
+                }
+            }
+          }
+        ]
+      },
+      {
+        "label":"Nav Bar Settings",
+        "settings": [
+          {
+            "type": "input",
+            "id": "nav_bar_height",
+            "label": "Nav Bar Default Height (px)"
+          },
+          {
+            "type": "boxModel",
+            "label": "Nav Bar Margins (px)",
+            "id": "nav_bar_margins",
+            "default": {
+                "top": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "right": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "bottom": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "left": {
+                    "value": "0",
+                    "type": "px"
+                }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Navbar-ETW/widget.html
+++ b/etownws-widgets/frontpage-widgets/Desktop-Navigation-ETW/Desktop-Navigation-Navbar-ETW/widget.html
@@ -1,0 +1,71 @@
+<script>
+    document.addEventListener("click",(e) => {
+        let openNavSection = document.querySelector(".navSectionContent-container.open");
+        if(openNavSection != null) {
+            if(!openNavSection.contains(e.target) && e.target != document.querySelector(`.navBarButton[data-nav-button-section='${openNavSection.dataset.navSectionName}']`)) {
+                openNavSection.classList.remove("open");
+                openNavSection.classList.add("closed");
+            }
+        }
+    });
+</script>
+<style>
+    .navPages-container#menu {
+        @media screen and (min-width: 801px) {
+            display: none !important;
+        }
+    }
+
+    @media screen and (max-width: 800px) {
+        .navBar {
+            display:none !important;
+        }
+    }
+    .navBar {
+        min-height:{{nav_bar_height}}px;
+        display:flex;
+        flex-direction:row;
+        text-align:center;
+        align-items: center;
+        justify-content: center;
+        margin: {{nav_bar_margins.top.value}}{{nav_bar_margins.top.type}} {{nav_bar_margins.right.value}}{{nav_bar_margins.right.type}} {{nav_bar_margins.bottom.value}}{{nav_bar_margins.bottom.type}} {{nav_bar_margins.left.value}}{{nav_bar_margins.left.type}};
+
+        .navBarButton {
+            text-decoration:none;
+        }
+    }
+
+    .navBarButton {
+        color: white;
+        font-size: {{nav_bar_button_font_size}}px;
+        width: {{nav_bar_button_width}}px;
+        border-radius: {{nav_bar_button_border_radius}}px;
+        margin: {{nav_bar_button_margins.top.value}}{{nav_bar_button_margins.top.type}} {{nav_bar_button_margins.right.value}}{{nav_bar_button_margins.right.type}} {{nav_bar_button_margins.bottom.value}}{{nav_bar_button_margins.bottom.type}} {{nav_bar_button_margins.left.value}}{{nav_bar_button_margins.left.type}};
+
+        &:hover {
+            cursor: pointer;
+        }
+    }
+
+    {{#each nav_sections}}
+        .navBarButton[data-nav-button-section="{{nav_bar_section_label}}"] {
+            background-color: {{nav_bar_button_color}};
+
+            &:hover {
+                background-color: {{nav_bar_button_color_hover}};
+            }
+        }
+    {{/each}}
+
+</style>
+
+<script>
+
+</script>
+    
+<div class="navBar">
+    {{#each nav_sections}}
+        <div class="navBarButton" data-nav-button-section="{{nav_bar_section_label}}" >{{nav_bar_section_label}}</div>
+    {{/each}}
+</div>
+

--- a/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Navbar-ETW/config.json
+++ b/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Navbar-ETW/config.json
@@ -1,0 +1,51 @@
+{
+  "text": "Simple Text with Styling",
+  "_.id": "1",
+  "color": "white",
+  "background_color": "#3C1F8C",
+  "font_size": {
+    "value": 24,
+    "type": "px"
+  },
+  "font_weight": "bold",
+  "text_align": {
+    "horizontal": "center"
+  },
+  "margin": {
+    "top": {
+      "value": "0",
+      "type": "px"
+    },
+    "right": {
+      "value": "0",
+      "type": "px"
+    },
+    "bottom": {
+      "value": "0",
+      "type": "px"
+    },
+    "left": {
+      "value": "0",
+      "type": "px"
+    }
+  },
+  "padding": {
+    "top": {
+      "value": "8",
+      "type": "px"
+    },
+    "right": {
+      "value": "24",
+      "type": "px"
+    },
+    "bottom": {
+      "value": "8",
+      "type": "px"
+    },
+    "left": {
+      "value": "24",
+      "type": "px"
+    }
+  },
+  "content": "I am a sample text"
+}

--- a/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Navbar-ETW/schema.json
+++ b/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Navbar-ETW/schema.json
@@ -1,0 +1,106 @@
+[
+  {
+    "type": "array",
+    "label": "Navigation Tabs",
+    "id": "tabs",
+    "defaultCount": 0,
+    "entryLabel": "Tab",
+    "schema": [
+      {
+        "type": "tab",
+        "label": "Design",
+        "sections": [
+          {
+            "settings": [
+              {
+                "type": "input",
+                "id": "tab_label",
+                "label": "Tab Name"
+              },
+              {
+                "type": "input",
+                "id": "page_url",
+                "label": "Page URL"
+              },
+              {
+                "type": "input",
+                "id": "submenu_id",
+                "label": "Submenu ID"
+              },
+              {
+                "type": "imageManager",
+                "id": "image",
+                "label": "Image",
+                "default": {
+                  "src": "",
+                  "type": "IMAGE_MANAGER"
+                }
+              },
+              {
+                "type": "color",
+                "id": "tab_button_hover",
+                "label": "Tab Hover Color"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "tab",
+    "label": "Design",
+    "sections": [
+      {
+        "settings": [
+          {
+            "type": "input",
+            "id": "image_height",
+            "label": "Image Height"
+          },
+          {
+            "type": "input",
+            "id": "image_width",
+            "label": "Image Width"
+          },
+          {
+            "type": "boxModel",
+            "label": "Image Margins (px)",
+            "id": "image_margins",
+            "default": {
+                "top": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "right": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "bottom": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "left": {
+                    "value": "0",
+                    "type": "px"
+                }
+            }
+          },
+          {
+            "type": "range",
+            "label": "Image Opacity",
+            "id": "image_opacity",
+            "typeMeta" : {
+              "rangeValues": {
+                "min": 0,
+                "max": 100,
+                "step": 1,
+                "unit": "%"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Navbar-ETW/widget.html
+++ b/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Navbar-ETW/widget.html
@@ -1,0 +1,166 @@
+<style>
+    header.is-open {
+
+        .navPages {
+            display: flex;
+            justify-content: center;
+
+            .navPages-list {
+                width: 100%;
+            }
+        }
+    }
+
+    header._searchBar {
+        [data-mobile-menu-toggle="mobileMenu"] {
+            display: inherit !important;
+        }
+    }
+
+    .mobileNavContent {
+
+        .navPages-list {
+            background-color: white;
+            width: 100%;
+        }
+
+        @media screen and (min-width: 801px) {
+            display: none;
+        }
+
+        .navPages-item, .navPages-action {
+            padding: 0;
+        }
+
+        a {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            color: black;
+
+            span {
+                margin: auto 0 auto 1rem;
+                width: 50%;
+                text-align: left;
+            }
+
+            img {
+                height: {{image_height}}px;
+                width: {{image_with}}px;
+                filter: grayscale(100%);
+                -webkit-filter: grayscale(100%);
+                margin: {{image_margins.top.value}}{{image_margins.top.type}} {{image_margins.right.value}}{{image_margins.right.type}} {{image_margins.bottom.value}}{{image_margins.bottom.type}} {{image_margins.left.value}}{{image_margins.left.type}};
+                opacity: calc({{image_opacity}}/100);
+            }
+
+            &:not([data-mobile-menu-toggle]) {
+                svg {
+                    opacity: 0;
+                }
+            }
+
+        }
+
+        .navPages-item {
+            a {
+                border-bottom: 1px solid gray;
+                border-top: 1px solid gray;
+            }
+
+            &~.navPages-item {
+                a {
+                    border-top: none;
+                }
+            }
+        }
+
+        .mobileMenu-toggle {
+            margin-right: 0;
+        }
+
+        svg {
+            height:30px;
+            width:30px;
+            margin: auto 0;
+        }
+    }
+
+    @media screen and (max-width: 800px) {
+        .navPages-container#menu > .container > .navPages {
+            
+        }
+    }
+
+    .navPages-container > .container {
+        padding: 0;
+        
+        .navPages-list {
+            padding: 0;
+        }
+    }
+
+    .navPages-container {
+
+        
+        > .navPages-container-header {
+            padding: 0 5px;
+            justify-content: space-between;
+        }
+    }
+
+    .navPages-container-header {
+        .header-logo-image {
+            filter: invert(1);
+            position: relative;
+            margin: unset;
+            min-height: 50px;
+        }
+
+        .mobileMenu-toggle:only-child {
+            margin-left: auto;
+        }
+    }
+
+    [data-mobile-menu-toggle="menu"] {
+        display: none;
+    }
+    [data-mobile-menu-toggle="mobileMenu"] {
+        @media screen and (max-width: 800px) {
+            display: block !important;
+        }
+    }
+</style>
+
+<div class="navPages-container" id="mobileMenu" data-menu>
+    <div class="navPages-container-header">
+        <img class="header-logo-image" src="https://cdn11.bigcommerce.com/s-gfzkqqzlfq/images/stencil/80x80/image-manager/etw-logo-white-no-bg.png">
+        <a href="#" class="mobileMenu-toggle" data-mobile-menu-toggle="mobileMenu" title="{{lang 'common.close'}}"><span class="mobileMenu-toggleIcon"><span class="_icon"></span></span></a>
+    </div>
+    <div class="container" id="bf-fix-menu-mobile">
+        <nav class="mobileNavContent navPages">
+            <ul class="navPages-list">
+                {{#each tabs}}
+                <li class="navPages-item navPages-item--standard">
+                    {{#if submenu_id}}
+                    <a href="#" class="navPages-action mobileMenu-toggle" data-mobile-menu-toggle="{{submenu_id}}" aria-controls="{{submenu_id}}" aria-expanded="false">
+                        <span>{{tab_label}}</span>
+                        <img src="{{image.src}}">
+                        <svg>
+                            <use xlink:href="#icon-chevron-right"></use>
+                        </svg>
+                    </a>
+                    {{else}}
+                    <a href="{{page_url}}" class="navPages-action">
+                        <span>{{tab_label}}</span>
+                        <img src="{{image.src}}">
+                        <svg>
+                            <use xlink:href="#icon-chevron-right"></use>
+                        </svg>
+                    </a>
+                    {{/if}}
+                </li>
+                {{/each}}
+            </ul>
+        </nav>
+    </div>
+</div>

--- a/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Subtab-ETW/config.json
+++ b/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Subtab-ETW/config.json
@@ -1,0 +1,51 @@
+{
+  "text": "Simple Text with Styling",
+  "_.id": "1",
+  "color": "white",
+  "background_color": "#3C1F8C",
+  "font_size": {
+    "value": 24,
+    "type": "px"
+  },
+  "font_weight": "bold",
+  "text_align": {
+    "horizontal": "center"
+  },
+  "margin": {
+    "top": {
+      "value": "0",
+      "type": "px"
+    },
+    "right": {
+      "value": "0",
+      "type": "px"
+    },
+    "bottom": {
+      "value": "0",
+      "type": "px"
+    },
+    "left": {
+      "value": "0",
+      "type": "px"
+    }
+  },
+  "padding": {
+    "top": {
+      "value": "8",
+      "type": "px"
+    },
+    "right": {
+      "value": "24",
+      "type": "px"
+    },
+    "bottom": {
+      "value": "8",
+      "type": "px"
+    },
+    "left": {
+      "value": "24",
+      "type": "px"
+    }
+  },
+  "content": "I am a sample text"
+}

--- a/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Subtab-ETW/schema.json
+++ b/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Subtab-ETW/schema.json
@@ -1,0 +1,106 @@
+[
+  {
+    "type": "array",
+    "label": "Navigation Tabs",
+    "id": "tabs",
+    "defaultCount": 0,
+    "entryLabel": "Tab",
+    "schema": [
+      {
+        "type": "tab",
+        "label": "Design",
+        "sections": [
+          {
+            "settings": [
+              {
+                "type": "input",
+                "id": "tab_label",
+                "label": "Tab Name"
+              },
+              {
+                "type": "input",
+                "id": "page_url",
+                "label": "Page URL"
+              },
+              {
+                "type": "imageManager",
+                "id": "image",
+                "label": "Image",
+                "default": {
+                  "src": "",
+                  "type": "IMAGE_MANAGER"
+                }
+              },
+              {
+                "type": "color",
+                "id": "tab_button_hover",
+                "label": "Tab Hover Color"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "tab",
+    "label": "Design",
+    "sections": [
+      {
+        "settings": [
+              {
+                "type": "input",
+                "id": "menu_id",
+                "label": "Menu ID"
+              },
+          {
+            "type": "input",
+            "id": "image_height",
+            "label": "Image Height"
+          },
+          {
+            "type": "input",
+            "id": "image_width",
+            "label": "Image Width"
+          },
+          {
+            "type": "boxModel",
+            "label": "Image Margins (px)",
+            "id": "image_margins",
+            "default": {
+                "top": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "right": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "bottom": {
+                    "value": "0",
+                    "type": "px"
+                },
+                "left": {
+                    "value": "0",
+                    "type": "px"
+                }
+            }
+          },
+          {
+            "type": "range",
+            "label": "Image Opacity",
+            "id": "image_opacity",
+            "typeMeta" : {
+              "rangeValues": {
+                "min": 0,
+                "max": 100,
+                "step": 1,
+                "unit": "%"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Subtab-ETW/widget.html
+++ b/etownws-widgets/frontpage-widgets/Mobile-Navigation-ETW/Mobile-Navigation-Subtab-ETW/widget.html
@@ -1,0 +1,51 @@
+<style>
+    .mobileNav-subMenu {
+        .navPages-container-header {
+            a {
+                line-height: 0;
+
+                svg {
+                    height:50px;
+                    width: 50px;
+                }
+            }
+        }
+    }
+
+    .mobileNavContent {
+        .navPages-action {
+            img {
+                width: {{image_width}}px;
+                height: {{image_height}}px;
+            }
+        }
+    }
+</style>
+
+{{#each tabs}}
+<div class="navPages-container mobileNav-subMenu" id="{{../menu_id}}" data-menu>
+    <div class="navPages-container-header">
+        <img class="header-logo-image" src="https://cdn11.bigcommerce.com/s-gfzkqqzlfq/images/stencil/80x80/image-manager/etw-logo-white-no-bg.png">
+        <a href="#" class="mobileMenu-toggle" data-mobile-menu-toggle="{{../menu_id}}" title="{{lang 'common.close'}}">
+            <svg>
+                <use xlink:href="#icon-chevron-left"></use>
+            </svg>
+        </a>
+    </div>
+    <div class="container" id="bf-fix-menu-mobile">
+        <nav class="mobileNavContent navPages">
+            <ul class="navPages-list">
+                <li class="navPages-item navPages-item--standard">
+                    <a class="navPages-action" href="{{page_url}}">
+                        <span>{{tab_label}}</span>
+                        <img src="{{image.src}}">
+                        <svg>
+                            <use xlink:href="#icon-chevron-right"></use>
+                        </svg>
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    </div>
+</div>
+{{/each}}


### PR DESCRIPTION
# Desktop-Navigation-Navbar
> This widget builds the navigation bar at the top of the page on desktop views.

## Scripts
### Adds event listener to document for click events
> The callback function for the listener checks if there is an open navigation section and then checks if the click target is inside of that content area or if it was on the tab button. If the target is not inside of the open tab content area or the button for the tab then the tab is closed
## Schema
### Array Settings (nav_sections)
> nav_bar_section_label - Text label to be displayed on the navigation bar button
> nav_bar_button_url - Currently unused
> nav_bar_button_color - Background color of the button
> nav_bar_button_color_hover - Background color of the button when hovering over it
### Widget Settings
#### Button Settings 
> nav_bar_button_width - Width of navigation bar buttons in pixels
> nav_bar_button_font_size - Font size of navigation bar button text in pixels
> nav_bar_button_border_radius - Border radius of navigation bar buttons in pixels
> nav_bar-button_margins - Margins of navigation bar buttons in pixels

#### Nav Bar Settings
> nav_bar_height - Default height of navigation bar in pixels
> nav_bar_margins - Margins of the navigation bar container in pixels

# Desktop-Navigation-Content
> This widget is the content for one of the tab buttons in the Desktop-Navigation-Navbar widget.

## Scripts
### Adds event listener to elements for click events in the content

## Schema
### Array Settings (nav_content_columns)
![image](https://github.com/user-attachments/assets/01a1b64e-f307-42db-a3c6-fbc07bdd5af8)


# Mobile
## Mobile navigation and content widgets exist in the same way that the desktop ones do. The main different between the two is the way the navigation elements are put together most other things are nearly identical
